### PR TITLE
Allow semigroupoids-6

### DIFF
--- a/numhask-space.cabal
+++ b/numhask-space.cabal
@@ -43,7 +43,7 @@ library
     , distributive   >=0.2.2   && <1
     , numhask        >=0.10.0  && <0.11
     , random         ^>=1.2
-    , semigroupoids  >=5       && <5.4
+    , semigroupoids  >=5       && <5.4 || >=6 && <6.1
     , tdigest        ^>=0.2.1
     , text           >=1.2.3.1 && <3
     , time           >=1.9.1   && <1.13


### PR DESCRIPTION
Tested with 
```
cabal test --allow-newer='tdigest:semigroupoids' -c 'semigroupoids>=6'
```
(`tdigest` bump is tracked in https://github.com/phadej/tdigest/issues/44)